### PR TITLE
Problem: wording in index.rst is incorrect

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -14,13 +14,10 @@ a placeholder for the EVM specification, but please feel free to
 `contribute new RFCs <https://github.com/sorpaas/etcrfc/compare>`_.
 
 We collect specifications for APIs, file formats, protocols, processes
-and compositions of RFCs which result in a blockchain soft forks.
+and compositions of RFCs.
 
 You can start contributing by sending a pull request to
 https://github.com/sorpaas/etcrfc on GitHub.
-
-Please `read this <https://etcrfc.that.world>`_ for the rendered
-content.
 
 Guidelines
 ----------


### PR DESCRIPTION
Solution: remove incorrect wordings

Those RFCs will also result in blockchain hard forks and there will be
RFCs that are unrelated to blockchains. `index.rst` will only be
displayed for rendered HTML.